### PR TITLE
Follow block breaking cooldown when breaking overlay

### DIFF
--- a/src/client/java/com/dooji/underlay/mixin/client/ClientPlayerInteractionManagerAccessor.java
+++ b/src/client/java/com/dooji/underlay/mixin/client/ClientPlayerInteractionManagerAccessor.java
@@ -8,4 +8,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 public interface ClientPlayerInteractionManagerAccessor {
     @Accessor("blockBreakingCooldown")
     void setBlockBreakingCooldown(int value);
+
+    @Accessor("blockBreakingCooldown")
+    int getBlockBreakingCooldown();
 }

--- a/src/client/java/com/dooji/underlay/mixin/client/MinecraftClientMixin.java
+++ b/src/client/java/com/dooji/underlay/mixin/client/MinecraftClientMixin.java
@@ -49,11 +49,12 @@ public class MinecraftClientMixin {
     }
 
     @Inject(method = "doAttack", at = @At("HEAD"), cancellable = true)
-    private void onLeftClick(CallbackInfoReturnable<Boolean> cir) {
+    private void handleInitialBreaking(CallbackInfoReturnable<Boolean> cir) {
         MinecraftClient client = MinecraftClient.getInstance();
 
         BlockPos overlayPos = UnderlayClient.findOverlayUnderCrosshair(client);
         if (overlayPos != null) {
+            UnderlayClient.breakOverlay(client, overlayPos);
             cir.setReturnValue(false);
             cir.cancel();
         }


### PR DESCRIPTION
Overlay will no longer break if the block breaking cooldown is not clear, which alleviates the problem where you may accidentally break the block and then break the overlay itself the following game tick.

It also now handles holding down the attack key to continue breaking overlays, feels as good as breaking any other real block :)